### PR TITLE
Replaces api required user token with header apikey

### DIFF
--- a/components/settingsForm.tsx
+++ b/components/settingsForm.tsx
@@ -14,7 +14,6 @@ import splitbee from '@splitbee/web'
 import { useAuth } from 'lib/auth'
 import useDbUser from 'lib/hooks/useDbUser'
 import { updateUser } from 'lib/db/users'
-import { ContinuousColorLegend } from 'react-vis'
 
 const SettingsForm = (): JSX.Element => {
   const { user } = useAuth()

--- a/lib/admin-db/infusions.ts
+++ b/lib/admin-db/infusions.ts
@@ -31,11 +31,24 @@ async function getInfusion(infusionId: string) {
   return { infusions }
 }
 
-async function getRecentUserInfusions(uid: string) {
+async function getRecentUserInfusionsByApiKey(apiKey: string) {
   try {
+    const userSnapshot = await adminFirestore
+      .collection('users')
+      .where('apiKey', '==', apiKey)
+      .limit(1)
+      .get()
+
+    if (!userSnapshot.docs[0]) {
+      throw new Error(
+        'Invalid API key. Reset your key on your profile page at Hemolog.com'
+      )
+    }
+    const user = userSnapshot.docs[0].data()
+
     const snapshot = await adminFirestore
       .collection('infusions')
-      .where('user.uid', '==', uid)
+      .where('user.uid', '==', user.uid)
       .where('deletedAt', '==', null)
       // TODO: Need to add a timestamp value to each infusion and replace createdAt
       // .orderBy('timestamp', 'asc')
@@ -56,9 +69,8 @@ async function getRecentUserInfusions(uid: string) {
 
     return { infusions }
   } catch (error) {
-    console.log('lower', error)
     return { error }
   }
 }
 
-export { getAllInfusions, getInfusion, getRecentUserInfusions }
+export { getAllInfusions, getInfusion, getRecentUserInfusionsByApiKey }

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -40,11 +40,12 @@ function useProvideAuth() {
       // TODO(michael) If user already exist then remove alertId
       // so it isn't overwritten when the user is updated on `createUser`
       // and overwrite the alertId created in the formatter.
-      // This needs to be cleaned up. isAdmin is also appended to
+      // This needs to be cleaned up. isAdmin, an dapiKey is also appended to
       // the user here.
       if (dbUser.exists) {
         user.alertId = dbUser.data()!.alertId
         user.isAdmin = dbUser.data()!.isAdmin
+        user.apiKey = dbUser.data()!.apiKey
         delete userWithoutToken.alertId
       }
 

--- a/lib/types/person.ts
+++ b/lib/types/person.ts
@@ -7,4 +7,5 @@ export interface Person {
   severity?: string
   medication?: string
   factor?: number
+  apiKey?: string
 }

--- a/lib/types/users.ts
+++ b/lib/types/users.ts
@@ -15,4 +15,5 @@ export interface UserType {
   provider: string
   token: string
   uid: string
+  apiKey?: string
 }

--- a/pages/api/recent-infusions.ts
+++ b/pages/api/recent-infusions.ts
@@ -1,14 +1,16 @@
-import { getRecentUserInfusions } from 'lib/admin-db/infusions'
+import { getRecentUserInfusionsByApiKey } from 'lib/admin-db/infusions'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const { token } = req.headers
-    if (!token) {
-      throw { message: 'Access denied. Missing valid token.' }
+    const { apikey } = req.headers
+    if (!apikey) {
+      throw { message: 'Access denied. Missing api key.' }
     }
 
-    const { infusions, error } = await getRecentUserInfusions(token as string)
+    const { infusions, error } = await getRecentUserInfusionsByApiKey(
+      apikey as string
+    )
 
     if (error) {
       throw error

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "baseUrl": "."
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es6"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
fixes: #33 

API keys are now generated for everyone when you visit your profile page. You can reset your key at anytime by clicking 'Reset key'. Right now the only endpoint is undocumented.

https://hemolog.com/api/recent-infusions. This gives the API user back the 3 most recent infusions similar to how the publicly available emergency page works.