### PR TITLE
Adds log-infusion API endpoint

### DIFF
--- a/components/profilePage.tsx
+++ b/components/profilePage.tsx
@@ -24,27 +24,24 @@ const ProfilePage = (): JSX.Element => {
     router.push('/emergency/print')
   }
 
-  const handleUpdateUserApiKey = useCallback(
-    () => async () => {
-      const newApiKey = await generateUniqueString(20)
-      updateUser(user!.uid, { apiKey: newApiKey })
-        .then(() => {
-          setToast({
-            text: 'API key updated!',
-            type: 'success',
-            delay: 5000,
-          })
+  const handleUpdateUserApiKey = useCallback(async () => {
+    const newApiKey = await generateUniqueString(20)
+    updateUser(user!.uid, { apiKey: newApiKey })
+      .then(() => {
+        setToast({
+          text: 'API key updated!',
+          type: 'success',
+          delay: 5000,
         })
-        .catch((error) =>
-          setToast({
-            text: `Something went wrong: ${error}`,
-            type: 'error',
-            delay: 10000,
-          })
-        )
-    },
-    [setToast, user]
-  )
+      })
+      .catch((error) =>
+        setToast({
+          text: `Something went wrong: ${error}`,
+          type: 'error',
+          delay: 10000,
+        })
+      )
+  }, [setToast, user])
 
   useEffect(() => {
     if (person && !person.apiKey) {

--- a/lib/admin-db/infusions.ts
+++ b/lib/admin-db/infusions.ts
@@ -1,6 +1,8 @@
 import { adminFirestore } from 'lib/firebase-admin'
 import { compareDesc, parseISO } from 'date-fns'
 
+import type { InfusionType } from '../db/infusions'
+
 async function getAllInfusions() {
   const snapshot = await adminFirestore.collection('infusions').get()
 
@@ -57,8 +59,12 @@ async function getRecentUserInfusionsByApiKey(apiKey: string) {
 
     const infusions: any = []
 
+    // TODO: Find out why I was adding an id here.
+    // The doc.id should already be available as the uid.
+    // Removing for now.
     snapshot.forEach((doc) => {
-      infusions.push({ id: doc.id, ...doc.data() })
+      // infusions.push({ id: doc.id, ...doc.data() })
+      infusions.push({ ...doc.data() })
     })
 
     // TODO: remove this hack after fixing the orderBy issue above
@@ -73,4 +79,55 @@ async function getRecentUserInfusionsByApiKey(apiKey: string) {
   }
 }
 
-export { getAllInfusions, getInfusion, getRecentUserInfusionsByApiKey }
+async function postInfusionByApiKey(
+  apiKey: string,
+  lastInfusion: InfusionType,
+  newInfusion: Partial<InfusionType>
+) {
+  try {
+    const userSnapshot = await adminFirestore
+      .collection('users')
+      .where('apiKey', '==', apiKey)
+      .limit(1)
+      .get()
+
+    if (!userSnapshot.docs[0]) {
+      throw new Error(
+        'Invalid API key. Reset your key on your profile page at Hemolog.com'
+      )
+    }
+
+    // Make room for new values
+    Object.assign(lastInfusion, {
+      createdAt: new Date().toISOString(),
+      cause: '',
+      sites: '',
+    })
+
+    delete lastInfusion.uid
+
+    // Keep data from last infusion and replace old with new data
+    const infusion = {
+      ...lastInfusion,
+      ...newInfusion,
+    }
+
+    await adminFirestore
+      .collection('infusions')
+      .add(infusion)
+      .then((docRef) => {
+        docRef.set({ uid: docRef.id, ...infusion })
+      })
+
+    return { infusion: { message: 'Success' } }
+  } catch (error) {
+    return { error }
+  }
+}
+
+export {
+  getAllInfusions,
+  getInfusion,
+  getRecentUserInfusionsByApiKey,
+  postInfusionByApiKey,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemolog",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/pages/api/log-infusion.ts
+++ b/pages/api/log-infusion.ts
@@ -1,0 +1,46 @@
+import {
+  getRecentUserInfusionsByApiKey,
+  postInfusionByApiKey,
+} from 'lib/admin-db/infusions'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+const logInfusion = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    return res.status(405).send('Requires POST method.')
+  }
+
+  try {
+    const { apikey } = req.query
+    if (!apikey) {
+      throw { message: 'Access denied. Missing api key.' }
+    }
+
+    if (!req.body) {
+      throw { message: 'Missing infusion data.' }
+    }
+
+    const { infusions, error } = await getRecentUserInfusionsByApiKey(
+      apikey as string
+    )
+
+    if (error) throw error
+
+    const mostRecentInfusion = infusions[0]
+
+    try {
+      const { infusion, error } = await postInfusionByApiKey(
+        apikey as string,
+        mostRecentInfusion,
+        req.body
+      )
+      if (error) throw error
+      return res.status(200).json(infusion)
+    } catch (error: any) {
+      return res.status(500).send(error.message)
+    }
+  } catch (error: any) {
+    return res.status(500).send(error.message)
+  }
+}
+
+export default logInfusion

--- a/pages/api/recent-infusions.ts
+++ b/pages/api/recent-infusions.ts
@@ -2,6 +2,9 @@ import { getRecentUserInfusionsByApiKey } from 'lib/admin-db/infusions'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 const recentInfusions = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    return res.status(405).send('Requires GET method.')
+  }
   try {
     const { apikey } = req.query
     if (!apikey) {


### PR DESCRIPTION
Duplicates previous log and updates type, date, sites, and cause.

I should probably update this a bit so it doesn't require a previous log to work. Simply creating an empty log to pull from in the case there isn't one should work. But also, this is fine for my use case. Logging from my Apple Watch, here we come.