### PR TITLE
Allows logging an infusion with no prior record, ensures user deletion removes related infusions, and adds robust avatar initial fallback

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -59,6 +59,12 @@ const Header = (props: Props): JSX.Element => {
   )
 
   if (user) {
+    const avatarInitial =
+      user.name?.charAt(0) ||
+      user.displayName?.charAt(0) ||
+      user.email?.charAt(0) ||
+      '?'
+
     return (
       <>
         <Grid.Container justify='space-between' alignItems='center'>
@@ -83,7 +89,7 @@ const Header = (props: Props): JSX.Element => {
                 <Popover content={popoverContent as any} placement='bottomEnd'>
                   <Avatar
                     src={user.photoUrl || '/images/favicon-32x32.png'}
-                    text={user?.displayName?.charAt(0)}
+                    text={avatarInitial}
                     style={{ cursor: 'pointer' }}
                     scale={2}
                   />

--- a/lib/admin-db/infusions.ts
+++ b/lib/admin-db/infusions.ts
@@ -1,7 +1,11 @@
 import { adminFirestore } from 'lib/firebase-admin'
 import { compareDesc, parseISO } from 'date-fns'
 
-import type { TreatmentType } from '../db/infusions'
+import {
+  TreatmentTypeEnum,
+  type TreatmentType,
+} from '../db/infusions'
+import type { AttachedUserType } from 'lib/types/users'
 
 async function getAllInfusions() {
   const snapshot = await adminFirestore.collection('infusions').get()
@@ -118,7 +122,7 @@ async function getRecentUserInfusionsByApiKey(
 
 async function postInfusionByApiKey(
   apiKey: string,
-  lastInfusion: TreatmentType,
+  lastInfusion: TreatmentType | null,
   newInfusion: Partial<TreatmentType>
 ) {
   try {
@@ -134,19 +138,54 @@ async function postInfusionByApiKey(
       )
     }
 
-    // Make room for new values
-    Object.assign(lastInfusion, {
-      createdAt: new Date().toISOString(),
-      cause: '',
-      sites: '',
-    })
+    const userDoc = userSnapshot.docs[0]
+    const baseUser: AttachedUserType = {
+      email: userDoc.data().email || '',
+      name: userDoc.data().name || userDoc.data().displayName || '',
+      photoUrl: userDoc.data().photoUrl || '',
+      uid: userDoc.data().uid || userDoc.id,
+    }
 
-    delete lastInfusion.uid
+    const now = new Date().toISOString()
+    const baseInfusion: TreatmentType = lastInfusion
+      ? { ...lastInfusion }
+      : {
+          cause: '',
+          createdAt: now,
+          date: newInfusion.date || now.slice(0, 10),
+          deletedAt: null,
+          medication: {
+            brand: newInfusion.medication?.brand || '',
+            costPerUnit: newInfusion.medication?.costPerUnit,
+            lot: newInfusion.medication?.lot,
+            units: newInfusion.medication?.units || 0,
+          },
+          sites: '',
+          type: newInfusion.type || TreatmentTypeEnum.PROPHY,
+          user: (newInfusion.user as AttachedUserType) || baseUser,
+        }
 
-    // Keep data from last infusion and replace old with new data
-    const infusion = {
-      ...lastInfusion,
+    const sanitizedBase = {
+      ...baseInfusion,
+      createdAt: now,
+      cause: baseInfusion.cause || '',
+      sites: baseInfusion.sites || '',
+      deletedAt: null,
+      user: baseInfusion.user || baseUser,
+    }
+
+    delete (sanitizedBase as Partial<TreatmentType>).uid
+
+    const infusion: TreatmentType = {
+      ...sanitizedBase,
       ...newInfusion,
+      user: (newInfusion.user as AttachedUserType) || sanitizedBase.user,
+      medication: {
+        ...sanitizedBase.medication,
+        ...(newInfusion.medication || {}),
+      },
+      createdAt: now,
+      deletedAt: null,
     }
 
     await adminFirestore

--- a/lib/db/users.ts
+++ b/lib/db/users.ts
@@ -12,10 +12,10 @@ async function createUser(uid: string, data: any) {
 }
 
 async function deleteUser(uid: string) {
-  firestore.collection('users').doc(uid).delete()
+  await firestore.collection('users').doc(uid).delete()
   const snapshot = await firestore
     .collection('infusions')
-    .where('userId', '==', uid)
+    .where('user.uid', '==', uid)
     .get()
 
   const batch = firestore.batch()

--- a/pages/api/log-treatment.ts
+++ b/pages/api/log-treatment.ts
@@ -25,7 +25,7 @@ const logTreatment = async (req: NextApiRequest, res: NextApiResponse) => {
 
     if (error) throw error
 
-    const mostRecentInfusion = infusions[0]
+    const mostRecentInfusion = infusions && infusions.length > 0 ? infusions[0] : null
 
     try {
       const { infusion, error } = await postInfusionByApiKey(


### PR DESCRIPTION
Fixes three bugs: first-time API logging crash, user deletion leaving behind infusions, and missing avatar fallback.

The API logging crashed because `postInfusionByApiKey` expected an existing infusion record, failing when none was present. The user deletion was not awaited, and the infusion cleanup query used an incorrect field, leading to orphaned data. The avatar fallback was insufficient, often resulting in a blank display.

---
<a href="https://cursor.com/background-agent?bcId=bc-77caf08b-c169-4238-b110-39d7cdf5b196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77caf08b-c169-4238-b110-39d7cdf5b196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows logging an infusion with no prior record, ensures user deletion removes related infusions, and adds robust avatar initial fallback.
> 
> - **Backend/API**:
>   - `postInfusionByApiKey` accepts `lastInfusion` as `null` and constructs a default base infusion/user; sanitizes fields and merges medication/user; enforces `createdAt`/`deletedAt`.
>   - `log-treatment` passes `null` when no prior infusion exists.
> - **Database**:
>   - `deleteUser` now awaits user doc deletion and deletes related infusions via `where('user.uid', '==', uid)`.
> - **UI**:
>   - `Header` computes `avatarInitial` from `name`/`displayName`/`email` with `?` fallback and uses it for `Avatar.text`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7682cd1059aef7a01fcd61ebcfc6e46ddf08bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->