### PR TITLE
Improve treatment dialog UX and mobile responsiveness

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,6 +8,7 @@ import {
   Spacer,
   useMediaQuery,
 } from '@geist-ui/react'
+import styled from 'styled-components'
 
 import { useAuth } from 'lib/auth'
 import Logo from 'components/logo'
@@ -67,48 +68,51 @@ const Header = (props: Props): JSX.Element | null => {
 
     return (
       <>
-        <Grid.Container justify='space-between' alignItems='center'>
-          <Grid>
-            <Logo />
-          </Grid>
-          <Grid>
-            <Grid.Container gap={2} alignItems='center'>
-              <Grid>
-                {!isMobile && (
-                  <Button
-                    onClick={() => setInfusionModalVisible(true)}
-                    auto
-                    type='success-light'
-                    scale={3 / 4}
-                  >
-                    New treatment
-                  </Button>
-                )}
-              </Grid>
-              <Grid>
-                {/* @ts-expect-error - Popover content prop has a type conflict with HTML content attribute */}
-                <Popover content={popoverContent} placement='bottomEnd'>
-                  <Avatar
-                    src={user.photoUrl || '/images/favicon-32x32.png'}
-                    text={avatarInitial}
-                    style={{ cursor: 'pointer' }}
-                    scale={2}
-                  />
-                </Popover>
-              </Grid>
-            </Grid.Container>
-          </Grid>
-        </Grid.Container>
+        <StyledHeaderCard>
+          <Grid.Container justify='space-between' alignItems='center'>
+            <Grid>
+              <Logo />
+            </Grid>
+            <Grid>
+              <Grid.Container gap={1.5} alignItems='center'>
+                <Grid>
+                  {!isMobile && (
+                    <Button
+                      onClick={() => setInfusionModalVisible(true)}
+                      auto
+                      type='success-light'
+                      scale={3 / 4}
+                      style={{ fontWeight: 600 }}
+                    >
+                      New treatment
+                    </Button>
+                  )}
+                </Grid>
+                <Grid>
+                  {/* @ts-expect-error - Popover content prop has a type conflict with HTML content attribute */}
+                  <Popover content={popoverContent} placement='bottomEnd'>
+                    <Avatar
+                      src={user.photoUrl || '/images/favicon-32x32.png'}
+                      text={avatarInitial}
+                      style={{ cursor: 'pointer' }}
+                      scale={2}
+                    />
+                  </Popover>
+                </Grid>
+              </Grid.Container>
+            </Grid>
+          </Grid.Container>
+        </StyledHeaderCard>
 
-        <Spacer />
+        <Spacer h={0.9} />
 
         {isMobile && (
           <Button
             onClick={() => setInfusionModalVisible(true)}
-            style={{ width: '100%' }}
+            style={{ width: '100%', fontWeight: 600 }}
             type='success-light'
           >
-            Log infusion
+            New treatment
           </Button>
         )}
 
@@ -125,3 +129,10 @@ const Header = (props: Props): JSX.Element | null => {
 }
 
 export default Header
+
+const StyledHeaderCard = styled.div`
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #fff8fb 100%);
+`

--- a/components/homePage.tsx
+++ b/components/homePage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Text, Spacer, Grid, Select, useMediaQuery } from '@geist-ui/react'
 import Filter from '@geist-ui/react-icons/filter'
 import { getYear } from 'date-fns'
+import styled from 'styled-components'
 
 import dynamic from 'next/dynamic'
 import InfusionTable from 'components/infusionTable'
@@ -84,22 +85,20 @@ const HomePage = (): JSX.Element => {
         </>
       )} */}
 
-      <Grid.Container
-        justify='space-between'
-        alignItems='center'
-        style={{ padding: '0 0 16px 0' }}
-      >
-        <Grid>
-          <Text h4 style={{ marginBottom: '0' }}>
-            Insights
-          </Text>
-        </Grid>
-        <Grid>
-          <Grid.Container gap={2} alignItems='center'>
-            <Grid alignItems='center'>
+      <StyledSectionHeader>
+        <Grid.Container
+          justify='space-between'
+          alignItems='center'
+          style={{ width: '100%', gap: '12px' }}
+        >
+          <Grid>
+            <Text h4 style={{ marginBottom: '0' }}>
+              Insights
+            </Text>
+          </Grid>
+          <Grid>
+            <StyledFilterWrap>
               <Filter size={16} />
-            </Grid>
-            <Grid>
               <Select
                 placeholder='Choose one'
                 disabled={infusionYears.length < 1}
@@ -118,10 +117,10 @@ const HomePage = (): JSX.Element => {
                   </Select.Option>
                 ))}
               </Select>
-            </Grid>
-          </Grid.Container>
-        </Grid>
-      </Grid.Container>
+            </StyledFilterWrap>
+          </Grid>
+        </Grid.Container>
+      </StyledSectionHeader>
       <Stats filterYear={filterYear} />
       <Spacer h={3} />
 
@@ -129,14 +128,22 @@ const HomePage = (): JSX.Element => {
       <Text h6 type='secondary'>
         Treatments are stacked by type (bleed, preventative, or prophy)
       </Text>
-      <Chart filterYear={filterYear} />
+      <StyledPanel>
+        <Chart filterYear={filterYear} />
+      </StyledPanel>
 
       <Spacer h={3} />
-      <Grid justify='space-between' alignItems='center'>
+      <Grid justify='space-between' alignItems='center' style={{ gap: '8px' }}>
         <Text h4>Treatments</Text>
-        {smallerThanSmall && <Text>Swipe →</Text>}
+        {smallerThanSmall && (
+          <Text small type='secondary'>
+            Swipe →
+          </Text>
+        )}
       </Grid>
-      <InfusionTable filterYear={filterYear} />
+      <StyledPanel>
+        <InfusionTable filterYear={filterYear} />
+      </StyledPanel>
     </>
   )
 }
@@ -162,3 +169,23 @@ const HomePage = (): JSX.Element => {
 // `
 
 export default HomePage
+
+const StyledSectionHeader = styled.div`
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #fff9fc 100%);
+`
+
+const StyledFilterWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const StyledPanel = styled.div`
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  padding: 8px;
+`

--- a/components/infusionModal.tsx
+++ b/components/infusionModal.tsx
@@ -194,7 +194,9 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
       {...bindings}
       style={{ width: isPhone ? 'calc(100vw - 16px)' : 'min(620px, 94vw)' }}
     >
-      <Modal.Title>{infusion ? 'Update treatment' : 'Log new treatment'}</Modal.Title>
+      <Modal.Title>
+        {infusion ? 'Update treatment' : 'Log new treatment'}
+      </Modal.Title>
       <StyledModalDescription small type='secondary'>
         Save your treatment details so stats stay accurate and easy to review.
       </StyledModalDescription>

--- a/components/infusionModal.tsx
+++ b/components/infusionModal.tsx
@@ -6,9 +6,11 @@ import {
   Button,
   Grid,
   useToasts,
+  useMediaQuery,
 } from '@geist-ui/react'
 import { useFormik } from 'formik'
 import { compareDesc, format, parseISO } from 'date-fns'
+import styled from 'styled-components'
 
 import { useAuth } from 'lib/auth'
 import { track } from 'lib/helpers'
@@ -46,6 +48,7 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
   const { user } = useAuth()
   const [, setToast] = useToasts()
   const { data: infusions } = useInfusions()
+  const isPhone = useMediaQuery('xs', { match: 'down' })
 
   // TODO:(michael) limit the firebase call instead of having
   // to return all the infusions and filtering them here
@@ -186,153 +189,168 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
   }
 
   return (
-    <Modal open={visible} {...bindings}>
-      <Modal.Title>Treatment</Modal.Title>
+    <Modal
+      open={visible}
+      {...bindings}
+      style={{ width: isPhone ? 'calc(100vw - 16px)' : 'min(620px, 94vw)' }}
+    >
+      <Modal.Title>{infusion ? 'Update treatment' : 'Log new treatment'}</Modal.Title>
+      <StyledModalDescription small type='secondary'>
+        Save your treatment details so stats stay accurate and easy to review.
+      </StyledModalDescription>
       <Modal.Content>
-        <form onSubmit={formik.handleSubmit}>
-          <Grid.Container gap={1}>
-            <Grid xs={8}>
-              <Button
-                width='100%'
-                name='type'
-                onClick={() =>
-                  formik.setFieldValue('type', TreatmentTypeEnum.PROPHY)
-                }
-                style={{
-                  marginRight: '8px',
-                  paddingLeft: '4px',
-                  paddingRight: '4px',
-                }}
-                type={
-                  formik.values.type === TreatmentTypeEnum.PROPHY
-                    ? 'warning-light'
-                    : 'default'
-                }
-              >
-                Prophy
-              </Button>
-            </Grid>
-            <Grid xs={8}>
-              <Button
-                width='100%'
-                name='type'
-                onClick={() =>
-                  formik.setFieldValue('type', TreatmentTypeEnum.BLEED)
-                }
-                style={{
-                  marginRight: '8px',
-                  paddingLeft: '4px',
-                  paddingRight: '4px',
-                }}
-                type={
-                  formik.values.type === TreatmentTypeEnum.BLEED
-                    ? 'success-light'
-                    : 'default'
-                }
-              >
-                Bleed
-              </Button>
-            </Grid>
-            <Grid xs={8}>
-              <Button
-                width='100%'
-                name='type'
-                onClick={() =>
-                  formik.setFieldValue('type', TreatmentTypeEnum.PREVENTATIVE)
-                }
-                style={{
-                  paddingLeft: '4px',
-                  paddingRight: '4px',
-                }}
-                type={
-                  formik.values.type === TreatmentTypeEnum.PREVENTATIVE
-                    ? 'error-light'
-                    : 'default'
-                }
-              >
-                Preventative
-              </Button>
-            </Grid>
-          </Grid.Container>
-          {user?.monoclonalAntibody && (
-            <Grid.Container gap={1}>
-              <Grid xs={24}>
+        <StyledForm onSubmit={formik.handleSubmit}>
+          <StyledSection>
+            <Text h6 style={{ margin: 0 }}>
+              Treatment type
+            </Text>
+            <Spacer h={0.3} />
+            <Grid.Container gap={0.8}>
+              <Grid xs={12} sm={8}>
                 <Button
                   width='100%'
                   name='type'
                   onClick={() =>
-                    formik.setFieldValue('type', TreatmentTypeEnum.ANTIBODY)
+                    formik.setFieldValue('type', TreatmentTypeEnum.PROPHY)
                   }
-                  style={{
-                    paddingLeft: '4px',
-                    paddingRight: '4px',
-                  }}
+                  style={TREATMENT_BUTTON_STYLE}
                   type={
-                    formik.values.type === TreatmentTypeEnum.ANTIBODY
-                      ? 'secondary-light'
+                    formik.values.type === TreatmentTypeEnum.PROPHY
+                      ? 'warning-light'
                       : 'default'
                   }
                 >
-                  Monoclonal antibody
+                  Prophy
                 </Button>
               </Grid>
+              <Grid xs={12} sm={8}>
+                <Button
+                  width='100%'
+                  name='type'
+                  onClick={() =>
+                    formik.setFieldValue('type', TreatmentTypeEnum.BLEED)
+                  }
+                  style={TREATMENT_BUTTON_STYLE}
+                  type={
+                    formik.values.type === TreatmentTypeEnum.BLEED
+                      ? 'success-light'
+                      : 'default'
+                  }
+                >
+                  Bleed
+                </Button>
+              </Grid>
+              <Grid xs={24} sm={8}>
+                <Button
+                  width='100%'
+                  name='type'
+                  onClick={() =>
+                    formik.setFieldValue('type', TreatmentTypeEnum.PREVENTATIVE)
+                  }
+                  style={TREATMENT_BUTTON_STYLE}
+                  type={
+                    formik.values.type === TreatmentTypeEnum.PREVENTATIVE
+                      ? 'error-light'
+                      : 'default'
+                  }
+                >
+                  Preventative
+                </Button>
+              </Grid>
+              {user?.monoclonalAntibody && (
+                <Grid xs={24}>
+                  <Button
+                    width='100%'
+                    name='type'
+                    onClick={() =>
+                      formik.setFieldValue('type', TreatmentTypeEnum.ANTIBODY)
+                    }
+                    style={TREATMENT_BUTTON_STYLE}
+                    type={
+                      formik.values.type === TreatmentTypeEnum.ANTIBODY
+                        ? 'secondary-light'
+                        : 'default'
+                    }
+                  >
+                    Monoclonal antibody
+                  </Button>
+                </Grid>
+              )}
             </Grid.Container>
-          )}
-          <Spacer />
-          <Input
-            id='date'
-            name='date'
-            htmlType='date'
-            onChange={formik.handleChange}
-            placeholder='Date'
-            value={formik.values.date}
-            width='100%'
-            crossOrigin={undefined}
-          >
-            <Text h6>Date</Text>
-          </Input>
-          <Spacer />
-          <Input
-            id='brand'
-            name='brand'
-            onChange={formik.handleChange}
-            placeholder='Brand name'
-            disabled={formik.values.type === TreatmentTypeEnum.ANTIBODY}
-            crossOrigin={undefined}
-            value={
-              formik.values.type === TreatmentTypeEnum.ANTIBODY
-                ? user?.monoclonalAntibody || ''
-                : formik.values.brand
-            }
-            width='100%'
-          >
-            <Text h6>Medication</Text>
-          </Input>
-          <Spacer h={0.8} />
+          </StyledSection>
+
+          <StyledSection>
+            <Text h6 style={{ margin: 0 }}>
+              Medication details
+            </Text>
+            <Spacer h={0.3} />
+            <Input
+              id='date'
+              name='date'
+              htmlType='date'
+              onChange={formik.handleChange}
+              placeholder='Date'
+              value={formik.values.date}
+              width='100%'
+              crossOrigin={undefined}
+            >
+              <Text h6>Date</Text>
+            </Input>
+            <Spacer />
+            <Input
+              id='brand'
+              name='brand'
+              onChange={formik.handleChange}
+              placeholder='Brand name'
+              disabled={formik.values.type === TreatmentTypeEnum.ANTIBODY}
+              crossOrigin={undefined}
+              value={
+                formik.values.type === TreatmentTypeEnum.ANTIBODY
+                  ? user?.monoclonalAntibody || ''
+                  : formik.values.brand
+              }
+              width='100%'
+            >
+              <Text h6>Medication</Text>
+            </Input>
+            {formik.values.type !== TreatmentTypeEnum.ANTIBODY && (
+              <>
+                <Spacer />
+                <Input
+                  crossOrigin={undefined}
+                  id='units'
+                  name='units'
+                  htmlType='number'
+                  labelRight='units'
+                  onChange={formik.handleChange}
+                  placeholder='3000'
+                  value={formik.values.units}
+                  width='100%'
+                >
+                  <Text h6>Amount</Text>
+                </Input>
+                <Spacer />
+                <Input
+                  crossOrigin={undefined}
+                  id='lot'
+                  name='lot'
+                  onChange={formik.handleChange}
+                  placeholder='Lot number'
+                  value={formik.values.lot}
+                  width='100%'
+                >
+                  <Text h6>Lot</Text>
+                </Input>
+              </>
+            )}
+          </StyledSection>
+
           {formik.values.type !== TreatmentTypeEnum.ANTIBODY && (
-            <>
-              <Input
-                crossOrigin={undefined}
-                id='units'
-                name='units'
-                htmlType='number'
-                labelRight='units'
-                onChange={formik.handleChange}
-                placeholder='3000'
-                value={formik.values.units}
-                width='100%'
-              />
-              <Spacer h={0.5} />
-              <Input
-                crossOrigin={undefined}
-                id='lot'
-                name='lot'
-                onChange={formik.handleChange}
-                placeholder='Lot number'
-                value={formik.values.lot}
-                width='100%'
-              />
-              <Spacer />
+            <StyledSection>
+              <Text h6 style={{ margin: 0 }}>
+                Bleed notes
+              </Text>
+              <Spacer h={0.3} />
               <Input
                 crossOrigin={undefined}
                 id='sites'
@@ -350,13 +368,13 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
                 id='cause'
                 name='cause'
                 onChange={formik.handleChange}
-                placeholder='Ran into a door 🤦‍♂️'
+                placeholder='Ran into a door'
                 value={formik.values.cause}
                 width='100%'
               >
                 <Text h6>Cause of bleed</Text>
               </Input>
-            </>
+            </StyledSection>
           )}
 
           {/* <Text h6>Notes</Text>
@@ -364,7 +382,7 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
             width='100%'
             placeholder='Notes to help you remember anything special about this infusion'
           /> */}
-        </form>
+        </StyledForm>
       </Modal.Content>
       <Modal.Action passive onClick={() => closeModal()}>
         Cancel
@@ -373,9 +391,33 @@ export default function InfusionModal(props: ModalProps): JSX.Element {
         onClick={handleSubmit}
         disabled={!formik.isValid}
         loading={formik.isSubmitting}
+        style={isPhone ? { fontWeight: 600 } : undefined}
       >
         {infusion ? 'Update Treatment' : 'Log Treatment'}
       </Modal.Action>
     </Modal>
   )
 }
+
+const TREATMENT_BUTTON_STYLE = {
+  minHeight: '42px',
+  paddingLeft: '6px',
+  paddingRight: '6px',
+}
+
+const StyledModalDescription = styled(Text)`
+  margin-top: -8px;
+  text-align: center;
+`
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`
+
+const StyledSection = styled.section`
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  padding: 14px;
+`

--- a/components/infusionTable.tsx
+++ b/components/infusionTable.tsx
@@ -258,5 +258,7 @@ export default function InfusionTable(props: InfusionTableProps): JSX.Element {
 }
 
 const StyledTableWrapper = styled.div`
-  overflow-x: scroll;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border-radius: 12px;
 `

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -105,10 +105,9 @@ const GlobalStyle = createGlobalStyle`
   }
 
   /*  targets Nextjs empty div issue */
-  /* TODO(michael): remove scrollbar on mobile */
   body > div:first-child {
-    overflow: -moz-scrollbars-vertical; 
-    overflow-y: scroll;
+    overflow-x: hidden;
+    overflow-y: auto;
     height: inherit;
   }
 

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -112,7 +112,7 @@ const StyledPage = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  max-width: 850pt;
+  max-width: 980px;
   width: 100%;
   margin: 0 auto;
 
@@ -125,13 +125,25 @@ const StyledPage = styled.div`
 `
 
 const StyledPageHeader = styled.header`
-  padding: 24px;
+  padding: 20px 24px 12px;
+
+  @media (max-width: 650px) {
+    padding: 16px 16px 8px;
+  }
 `
 
 const StyledPageContent = styled.main`
   padding: 0 24px;
+
+  @media (max-width: 650px) {
+    padding: 0 16px;
+  }
 `
 
 const StyledPageSection = styled.section`
-  padding: 40px 0 0 0;
+  padding: 28px 0 0;
+
+  @media (max-width: 650px) {
+    padding-top: 20px;
+  }
 `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refresh the top app shell with a cleaner header card and stronger mobile CTA for creating treatments
- redesign the new-treatment modal into clearer sections with better spacing and treatment-type controls that wrap cleanly on narrow viewports
- polish home-page visual hierarchy with section panels and mobile-friendly spacing adjustments
- improve horizontal scrolling behavior for the treatments table and prevent forced page overflow on small screens

## Testing
- `pnpm lint` ✅
- `pnpm build` ⚠️ fails due pre-existing missing module import in `components/feedbackPage.tsx` (`components/loadingScreen`), unrelated to this UI diff
- manual UI walkthrough at 375px viewport ✅ (open new-treatment dialog, toggle type buttons, scroll through fields and verify readability)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afb3ef1c-f44e-4f5d-a530-c8147e7f9cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afb3ef1c-f44e-4f5d-a530-c8147e7f9cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

